### PR TITLE
Add environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ The API will be available at `http://localhost:8000` and the interactive docs ca
 A default administrator account is created automatically with username `admin` and password `admin123`. Use these credentials to log in and create additional users.
 
 This is an MVP using an in-memory database and is not meant for production use.
+
+## Configuration
+
+The application reads several environment variables using `pydantic-settings`:
+
+- `SECRET_KEY` - secret used to sign JWT tokens.
+- `DATABASE_URL` - connection string for the database.
+- `APP_ENV` - name of the environment (e.g. `development` or `production`).
+
+You can define these variables in a `.env` file for local development or set them in your deployment environment.

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,12 @@
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    SECRET_KEY: str = "secret"
+    DATABASE_URL: str = "sqlite:///./db.sqlite3"
+    APP_ENV: str = "development"
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = True

--- a/app/main.py
+++ b/app/main.py
@@ -6,17 +6,19 @@ from datetime import datetime, timedelta
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 
+from .config import Settings
+
 from .models import User, Project, Batch, PerformanceLog, database, get_user_by_username
 from .models import create_user, get_user, update_batch_status, create_project, create_batch
 from .models import get_batch, log_performance
 
-SECRET_KEY = "secret"
+settings = Settings()
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-app = FastAPI()
+app = FastAPI(debug=settings.APP_ENV != "production")
 
 
 @app.on_event("startup")
@@ -89,7 +91,7 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     else:
         expire = datetime.utcnow() + timedelta(minutes=15)
     to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
 
@@ -100,7 +102,7 @@ async def get_current_user(token: str = Depends(oauth2_scheme)):
         headers={"WWW-Authenticate": "Bearer"},
     )
     try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
         username: str = payload.get("sub")
         if username is None:
             raise credentials_exception

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-jose[cryptography]
 passlib[bcrypt]
 httpx
 python-multipart
+pydantic-settings


### PR DESCRIPTION
## Summary
- add config module for environment variables
- use Settings in the FastAPI startup
- mention env variables in README
- include pydantic-settings in requirements

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ee8e6420832eaecd4e69f2676fe2